### PR TITLE
Some suggested adjustments (List::Util) and fixes (for AnyEvent)

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -20,7 +20,7 @@ my $builder = Module::Build->new(
         'Scalar::Util'   => 0,
         'IO::AtomicFile' => 0,
         'Fcntl'          => 0,
-        'List::MoreUtils' => 0,
+        'List::Util'     => '1.33',
     },
     build_requires => {
         'Test::More'        => 0,

--- a/lib/IO/Any.pm
+++ b/lib/IO/Any.pm
@@ -13,7 +13,7 @@ use IO::File;
 use IO::AtomicFile;
 use File::Spec;
 use Fcntl qw(:flock);
-use List::MoreUtils qw(none any);
+use List::Util qw(none any);
 
 sub new {
     my $class = shift;
@@ -290,7 +290,7 @@ Returns filehandle. L<IO::String> for 'string', L<IO::File> for 'file'.
 Here are available C<%$options> options:
 
     atomic    true/false if the file operations should be done using L<IO::AtomicFile> or L<IO::File>
-    BINARY    filehandles opened in binary mode, otherwise by default ":utf8" is set
+    BINMODE   filehandles opened in the given mode, otherwise by default ":utf8" is set
     LOCK_SH   lock file for shared access
     LOCK_EX   lock file for exclusive
     LOCK_NB   lock file non blocking (will throw an excpetion if file is

--- a/t/02_IO-Any_AnyEvent.t
+++ b/t/02_IO-Any_AnyEvent.t
@@ -32,30 +32,32 @@ exit main();
 sub main {
 	my $tmpdir = tempdir( CLEANUP => 1 );
 
+	my $opt = { BINMODE => ':raw' };
+
 	eq_or_diff(
-		[ IO::Any->slurp([$Bin, 'stock', '01.txt']) ],
+		[ IO::Any->slurp([$Bin, 'stock', '01.txt'], $opt) ],
 		[ qq{1\n22\n333\n} ],
 		'[ IO::Any->slurp() ]'
 	);
 	eq_or_diff(
-		scalar IO::Any->slurp([$Bin, 'stock', '01.txt']),
+		scalar IO::Any->slurp([$Bin, 'stock', '01.txt'], $opt),
 		qq{1\n22\n333\n},
 		'scalar IO::Any->slurp()'
 	);
 	eq_or_diff(
-		scalar IO::Any->slurp(\qq{1\n22\n333\n}),
+		scalar IO::Any->slurp(\qq{1\n22\n333\n}, $opt),
 		qq{1\n22\n333\n},
 		'IO::Any->slurp() string'
 	);
 	
-	IO::Any->spew([$tmpdir, '02-test.txt'], qq{4\n55\n666\n});
+	IO::Any->spew([$tmpdir, '02-test.txt'], qq{4\n55\n666\n}, $opt);
 	eq_or_diff(
 		scalar read_file(File::Spec->catfile($tmpdir, '02-test.txt')),
 		qq{4\n55\n666\n},
 		'IO::Any->spew()'
 	);
 	my $str;
-	IO::Any->spew(\$str, qq{1\n22\n333\n});
+	IO::Any->spew(\$str, qq{1\n22\n333\n}, $opt);
 	eq_or_diff(
 		$str,
 		qq{1\n22\n333\n},


### PR DESCRIPTION
This PR:

* uses `List::Util` instead of `List::MoreUtils` for `none` and `any`. As of `List::Utils` 1.33 these are available and `List::Util` is bundled with Perl
* The documentation refers to a BINARY option, but when I tried to use it it didn't work, there DOES appear to be a BINMODE option that lets you override the file mode, so I suggest updating the documentation to reflect that.
* the AnyEvent test loops forever for me with this error:

```
...
EV: error in callback (ignoring): sysread() isn't allowed on :utf8 handles at /Users/ollisg/opt/perl/5.40.0/lib/site_perl/5.40.0/darwin-2level/AnyEvent/Handle.pm line 2005.
EV: error in callback (ignoring): sysread() isn't allowed on :utf8 handles at /Users/ollisg/opt/perl/5.40.0/lib/site_perl/5.40.0/darwin-2level/AnyEvent/Handle.pm line 2005.
EV: error in callback (ignoring): sysread() isn't allowed on :utf8 handles at /Users/ollisg/opt/perl/5.40.0/lib/site_perl/5.40.0/darwin-2level/AnyEvent/Handle.pm line 2005.
EV: error in callback (ignoring): sysread() isn't allowed on :utf8 handles at /Users/ollisg/opt/perl/5.40.0/lib/site_perl/5.40.0/darwin-2level/AnyEvent/Handle.pm line 2005.
EV: error in callback (ignoring): sysread() isn't allowed on :utf8 handles at /Users/ollisg/opt/perl/5.40.0/lib/site_perl/5.40.0/darwin-2level/AnyEvent/Handle.pm line 2005.
EV: error in callback (ignoring): sysread() isn't allowed on :utf8 handles at /Users/ollisg/opt/perl/5.40.0/lib/site_perl/5.40.0/darwin-2level/AnyEvent/Handle.pm line 2005.
EV: error in callback (ignoring): sysread() isn't allowed on :utf8 handles at /Users/ollisg/opt/perl/5.40.0/lib/site_perl/5.40.0/darwin-2level/AnyEvent/Handle.pm line 2005.
...
```

I suspect some change in AE, or maybe Perl.  My suggestion is to just run the test with `BINMODE => ":raw"` to force binary mode.  Although you may also want to detect and error more gracefully that what AnyEvent is currently allowing.